### PR TITLE
Prototype WebShareTarget support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -30,5 +30,21 @@
       "type": "image/jpg",
       "sizes": "540x720"
     }
-  ]
+  ],
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "url": "url",
+      "text": "text",
+      "files": [
+        {
+          "name": "image",
+          "accept": ["image/*"]
+        }
+      ]
+    }
+  }
 }

--- a/sw.js
+++ b/sw.js
@@ -19,6 +19,10 @@ importScripts(workboxAddr);
 
 const cacheName = 'app-cache';
 
+const mainDBName = 'appDB';
+const objStoreName = 'imageStore';
+const mainImageName = 'mainImage';
+
 self.addEventListener('install', function (event) {
   // precache all assets
   event.waitUntil(
@@ -34,6 +38,54 @@ self.addEventListener('install', function (event) {
     }),
   );
 });
+
+workbox.routing.registerRoute(
+  ({url}) => url.pathname === '/share-target',
+  async ({request}) => {
+    const data = await request.formData();
+
+    if (!indexedDB) { /* TODO: display error message */ }
+
+    let dbOpenRequest = null;
+    await new Promise((resolve, reject) => {
+      // TODO: consider using https://github.com/jakearchibald/idb
+      dbOpenRequest = indexedDB.open(mainDBName);
+      dbOpenRequest.addEventListener('success', () => {
+        console.log('Database initialized');
+        resolve();
+      });
+      dbOpenRequest.addEventListener('error', (e) => {
+        console.log('error loading db:', e);
+        // TODO: display error
+        reject();
+      });
+      dbOpenRequest.addEventListener('upgradeneeded', (e) => {
+        console.log(`DB update request:`, e);
+        e.target.result.createObjectStore(objStoreName);
+      });
+    });
+
+    // TODO: handle invalid share
+    storeFile(data.get('image'), dbOpenRequest);
+    return Response.redirect('/index.html', 302);
+  },
+  'POST'
+);
+
+async function storeFile(f, dbOpenRequest) {
+  const b = new Blob([await f.arrayBuffer()]);
+  // TODO: perhaps prompt before silently replacing old image, if one exists?
+  const t = dbOpenRequest.result.transaction(objStoreName, 'readwrite').objectStore(objStoreName).put(b, mainImageName);
+  // TODO: display "saving..." message/spinner?
+  t.addEventListener('success', (e) => {
+    console.log('put success:', e)
+  });
+  t.addEventListener('error', (e) => {
+    console.log('put error:', e)
+    // TODO: display error
+  });
+  // TODO: add option to remove from storage
+}
 
 workbox.routing.registerRoute(
   ({url}) => true,


### PR DESCRIPTION
There's a fair bit of code copied from [index.js](https://github.com/GoogleChromeLabs/llaminator/blob/f0597dff3a382e608d261853424dbdee69a21a7f/index.js) into [sw.js](https://github.com/GoogleChromeLabs/llaminator/compare/main...glennhartmann:web-share-target?expand=1#diff-4bf19ba58dc8ea29d3977699ebcb1aaf2bc12441939754be7038e7fd13141ce0). Not really sure how to share code properly - the regular script is able to use [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) if it's a module (and the scripts it's importing are modules). But the ServiceWorker seems to only be able to import with [importScripts](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts), which doesn't really like modules.

Short of using a build system, is there a "right way" to do this?

Fixes https://github.com/GoogleChromeLabs/llaminator/issues/6 ([preview](https://glennhartmann.github.io/llaminator/))