### PR TITLE
Specify a MIME type when instantiating blob to ensure image results aren't saved as .txt

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ async function onFileInputChange(e, dbOpenRequest, imgElement) {
   console.log(e.target.value);
   if (e.target.files.length === 0) return;
   const f = e.target.files[0]; // TODO: null-check
-  const b = new Blob([await f.arrayBuffer()]);
+  const b = new Blob([await f.arrayBuffer()], { type: f.type });
   // TODO: perhaps prompt before silently replacing old image, if one exists?
   imgElement.src = window.URL.createObjectURL(b);
   const t = dbOpenRequest.result.transaction(objStoreName, 'readwrite').objectStore(objStoreName).put(b, mainImageName);


### PR DESCRIPTION
Fixes #9 

👋 @glennhartmann 

To avoid the image results saving as `.txt` files, we can specify a MIME type during blob instantiation by providing the [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) constructor a second param which is an object with key `type` representing [blob.type](https://developer.mozilla.org/en-US/docs/Web/API/Blob/type). This way the image results save as their specific MIME type.

```js
const b = new Blob([await f.arrayBuffer()], { type: f.type }); // f.type would be image/png, image/jpeg, application/pdf etc
```




https://user-images.githubusercontent.com/48612525/142803906-1c0dd0c7-6103-4d8c-8f98-b65d1cadc087.mov
