### PR TITLE
Attempt to convert service worker to TS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,17 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "llaminator",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "typescript": "^4.5.2"
+        "workbox-routing": "^6.4.1",
+        "workbox-strategies": "^6.4.1"
       },
       "devDependencies": {
         "@web/dev-server": "^0.1.28",
-        "@web/dev-server-esbuild": "^0.2.16"
+        "@web/dev-server-esbuild": "^0.2.16",
+        "typescript": "^4.5.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1660,6 +1663,7 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
       "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1747,6 +1751,27 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/workbox-core": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.4.1.tgz",
+      "integrity": "sha512-5hosqpSK+48jHlj+5EHN5dtH1Ade4fqTe4+xX3U9wWK1SDaXEqXpVxdHuBqYfg75UE1PUINA0rhMZWTqeGoLFg=="
+    },
+    "node_modules/workbox-routing": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.4.1.tgz",
+      "integrity": "sha512-FIy27mwM3WdDASOTMX10OZ8q3Un47ULeDtDrDAKfWYIP/oTF2xoA1/HtXpOjBlyg5VP/poPX5GDojXHXAXpfzQ==",
+      "dependencies": {
+        "workbox-core": "6.4.1"
+      }
+    },
+    "node_modules/workbox-strategies": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.4.1.tgz",
+      "integrity": "sha512-2UQ+7Siy4Z5QG2LebbVhDLmPG3M7bVo/tZqN4LNUGXS6fDlpbTTK6A3Hu0W8gCVwIX0tSg7U3mVhDntH4qt3Dg==",
+      "dependencies": {
+        "workbox-core": "6.4.1"
       }
     },
     "node_modules/ws": {
@@ -3078,7 +3103,8 @@
     "typescript": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw=="
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true
     },
     "typical": {
       "version": "4.0.0",
@@ -3130,6 +3156,27 @@
           "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
           "dev": true
         }
+      }
+    },
+    "workbox-core": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.4.1.tgz",
+      "integrity": "sha512-5hosqpSK+48jHlj+5EHN5dtH1Ade4fqTe4+xX3U9wWK1SDaXEqXpVxdHuBqYfg75UE1PUINA0rhMZWTqeGoLFg=="
+    },
+    "workbox-routing": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.4.1.tgz",
+      "integrity": "sha512-FIy27mwM3WdDASOTMX10OZ8q3Un47ULeDtDrDAKfWYIP/oTF2xoA1/HtXpOjBlyg5VP/poPX5GDojXHXAXpfzQ==",
+      "requires": {
+        "workbox-core": "6.4.1"
+      }
+    },
+    "workbox-strategies": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.4.1.tgz",
+      "integrity": "sha512-2UQ+7Siy4Z5QG2LebbVhDLmPG3M7bVo/tZqN4LNUGXS6fDlpbTTK6A3Hu0W8gCVwIX0tSg7U3mVhDntH4qt3Dg==",
+      "requires": {
+        "workbox-core": "6.4.1"
       }
     },
     "ws": {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,9 @@
     "@web/dev-server": "^0.1.28",
     "@web/dev-server-esbuild": "^0.2.16",
     "typescript": "^4.5.2"
+  },
+  "dependencies": {
+    "workbox-routing": "^6.4.1",
+    "workbox-strategies": "^6.4.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+    navigator.serviceWorker.register('sw.ts');
   });
 } else {
   // TODO display error message and fail gracefully

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -32,11 +32,11 @@ self.addEventListener('install', function (event: Event): void {
   (event as InstallEvent).waitUntil(
     caches.open(cacheName).then(function (cache) {
       return cache.addAll([
-        '/',
-        '/index.html',
-        '/index.ts',
-        '/manifest.json',
-        '/sw.ts',
+        '/src/',
+        '/src/index.html',
+        '/src/index.ts',
+        '/src/manifest.json',
+        '/src/sw.ts',
       ]);
     }),
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "esModuleInterop": false,
     "noEmitOnError": true,
-    "lib": ["esnext", "dom", "dom.iterable"],
+    "lib": ["esnext", "dom", "dom.iterable", "webworker"],
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "./",


### PR DESCRIPTION
(depends on https://github.com/GoogleChromeLabs/llaminator/pull/14)

`npx tsc --lib webworker src/sw.ts` builds this without error (although `npx tsc src/sw.ts` does not, which makes me question what exactly the `tsconfig.json` does).

But I get this extremely helpful runtime error when using `npm run-script serve`:

```
Uncaught SyntaxError: Cannot use import statement outside a module
Uncaught (in promise) TypeError: Failed to register a ServiceWorker for scope ('http://localhost:4629/src/') with script ('http://localhost:4629/src/sw.ts'): ServiceWorker script evaluation failed
```

Any ideas? Shouldn't ESBuild be taking care of this?

(This is what I mean when I say that setting up typescript and a build system is a massive mess)