### PR TITLE
add start_url back in, as it is required for installability

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,6 +13,7 @@
       "sizes": "512x512"
     }
   ],
+  "start_url": ".",
   "background_color": "#3367D6",
   "display": "standalone",
   "theme_color": "#3367D6",


### PR DESCRIPTION
Removed in https://github.com/GoogleChromeLabs/llaminator/pull/18