### PR TITLE
Replace 'process.env.NODE_ENV' in build

### DIFF
--- a/build_common.mjs
+++ b/build_common.mjs
@@ -19,6 +19,7 @@ function replaceConfig(root) {
     preventAssignment: true,
     values: {
       '__APP_ROOT__': root,
+      'process.env.NODE_ENV': '""'
     },
   };
 }


### PR DESCRIPTION
Fixes:

Uncaught ReferenceError: process is not defined at
node_modules/workbox-core/models/messages/messageGenerator.js:24