### PR TITLE
navigator.hasOwnProperty('') -> '' in navigator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,6 @@ async function onFileInputChange(e: Event, dbOpenRequest: IDBOpenDBRequest, imgE
 function displayIfShareEnabled(target: HTMLElement, blob: Blob): void {
   const f = fileFromBlob(blob);
   if ('share' in navigator && 'canShare' in navigator &&
-      /** @ts-ignore navigator.canShare isn't included in TypeScript's IDL? */
       navigator.canShare({files: [f]})) {
     target.style.display = 'block';
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ async function onFileInputChange(e: Event, dbOpenRequest: IDBOpenDBRequest, imgE
 
 function displayIfShareEnabled(target: HTMLElement, blob: Blob): void {
   const f = fileFromBlob(blob);
-  if (navigator.hasOwnProperty('share') && navigator.hasOwnProperty('canShare') &&
+  if ('share' in navigator && 'canShare' in navigator &&
       /** @ts-ignore navigator.canShare isn't included in TypeScript's IDL? */
       navigator.canShare({files: [f]})) {
     target.style.display = 'block';


### PR DESCRIPTION
seems to work, ¯\_(ツ)_/¯