### PR TITLE
set service worker type to 'module'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('__APP_ROOT__/sw.ts');
+    navigator.serviceWorker.register('__APP_ROOT__/sw.ts', { type: 'module' });
   });
 } else {
   // TODO display error message and fail gracefully


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/llaminator/issues/19, mostly.

The service worker will still be broken until https://github.com/GoogleChromeLabs/llaminator/pull/29 lands.