### PR TITLE
canonically use ".js" filenames for compiled ".ts"

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -22,7 +22,6 @@ import resolve from '@rollup/plugin-node-resolve';
 import { replaceConfig } from './build_common.mjs';
 
 const outDir = 'dist';
-const entryFileNamesPattern = '[name].ts';
 const replacePluginInstance = replace(replaceConfig(''));
 
 export default [
@@ -31,7 +30,6 @@ export default [
     output: {
       dir: outDir,
       sourcemap: true,
-      entryFileNames: entryFileNamesPattern,
     },
     plugins: [
       clear({ targets: [outDir] }),
@@ -53,7 +51,6 @@ export default [
     output: {
       dir: outDir,
       sourcemap: true,
-      entryFileNames: entryFileNamesPattern,
     },
     plugins: [
       replacePluginInstance,

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
     <meta name="description" content="TODO">
     <title>Llaminator</title>
     <link rel="manifest" href="manifest.json">
-    <script src="index.ts"></script>
+    <script src="index.js"></script>
   </head>
   <body>
     <img></img>

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('__APP_ROOT__/sw.ts');
+    navigator.serviceWorker.register('__APP_ROOT__/sw.js');
   });
 } else {
   // TODO display error message and fail gracefully

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -32,9 +32,9 @@ self.addEventListener('install', function (event): void {
       return cache.addAll([
         '__APP_ROOT__/',
         '__APP_ROOT__/index.html',
-        '__APP_ROOT__/index.ts',
+        '__APP_ROOT__/index.js',
         '__APP_ROOT__/manifest.json',
-        '__APP_ROOT__/sw.ts',
+        '__APP_ROOT__/sw.js',
       ]);
     }),
   );

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -15,8 +15,10 @@
  */
 
 import { esbuildPlugin } from '@web/dev-server-esbuild';
+import { existsSync } from 'fs';
 import { fromRollup } from '@web/dev-server-rollup';
 import { replaceConfig } from './build_common.mjs';
+import * as path from 'path';
 import rollupReplace from '@rollup/plugin-replace';
 
 const replace = fromRollup(rollupReplace);
@@ -24,6 +26,48 @@ const replace = fromRollup(rollupReplace);
 export default {
   plugins: [
     replace(replaceConfig('/src')),
-    esbuildPlugin({ ts: true })
+    esbuildPlugin({ ts: true }),
+  ],
+  middleware: [
+    jsToTs,
   ],
 };
+
+// rewrites local URLs from ending in '.js' to ending in '.ts' if the latter
+// exists but the former does not.
+function jsToTs(context, next) {
+  if (!context.url.startsWith('/src/')) {
+    // not in our local code, don't try to rewrite
+    return next();
+  }
+
+  // unfortunately, it's necessary to split and recombine the path (using
+  // fs.join()) for this to work properly on Windows.
+  const split_url = context.url.split('/'); // maybe not a great idea for URLs in general?
+  const filename = split_url[split_url.length - 1];
+  if (!filename.endsWith('.js')) {
+    // not .js, no need to rewrite
+    return next();
+  }
+
+  // split_url ends in '.js', new_split_path will end in '.ts'
+  let new_split_path = [...split_url];
+  new_split_path[new_split_path.length - 1] = replaceExt(filename);
+
+  if (!splitPathExists(split_url) && splitPathExists(new_split_path)) {
+    context.url = new_split_path.join('/');
+  }
+
+  return next();
+}
+
+// replace last 3 characters (assumed to be '.js') with '.ts'
+function replaceExt(str) {
+  return str.substr(0, str.length - 3) + '.ts';
+}
+
+// check if the file exists on the local filesystem (after removing the
+// first entry of the array, which is assumed to be '')
+function splitPathExists(split_path) {
+  return existsSync(path.join(...split_path.slice(1)))
+}


### PR DESCRIPTION
This makes the `npm run-script serve` and
`npm run-script build` setups more consistent and
fixes https://github.com/GoogleChromeLabs/llaminator/issues/24