### PR TITLE
Re-implement the fab, drop the dependency on MWC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@material/mwc-fab": "^0.25.3",
+        "@material/fab": "^13.0.0",
         "@material/top-app-bar": "^13.0.0",
         "idb": "^7.0.0",
         "lit": "^2.0.2",
@@ -1774,36 +1774,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@lit/reactive-element": {
-      "version": "1.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.4.tgz",
-      "integrity": "sha512-dJMha+4NFYdpnUJzRrWTFV5Hdp9QHWFuPnaoqonrKl4lGJVnYez9mu8ev9F/5KM47tjAjh22DuRHrdFDHfOijA=="
-    },
-    "node_modules/@material/animation": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-OjxWJYSRNs4vnPe8NclaNn+TsNc8TR/wHusGtezF5F+wl+5mh+K69BMXAmURtq3idoRg4XaOSC/Ohk1ovD1fMQ==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@material/base": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-vy5SQt+jcwwdRFfBvtpVdpULUBujecVUKOXcopaQoi2XIzI5EBHuR4gPN0cd1yfmVEucD6p2fvVv2FJ3Ngr61w==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@material/dom": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-iUpZG6Bb2l/PfNV2Fb/pXfG1p4Bz4PC9A7ATPlKfcU5HioObcnYVc/+Hrtaw8eu28BNIc+VVROtbfpqG/YgKSQ==",
-      "dependencies": {
-        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@material/elevation": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-13.0.0.tgz",
@@ -1859,68 +1829,87 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@material/feature-targeting": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
+    "node_modules/@material/fab": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-13.0.0.tgz",
+      "integrity": "sha512-qOi+XWEZWUR5T961UjSorgqm5VaanuZtRN3nsrKqHH1p0L8fYRc3qkGIChlaY9p7BcOYMCynXJzT+MfELVrcwA==",
+      "dependencies": {
+        "@material/animation": "^13.0.0",
+        "@material/dom": "^13.0.0",
+        "@material/elevation": "^13.0.0",
+        "@material/feature-targeting": "^13.0.0",
+        "@material/ripple": "^13.0.0",
+        "@material/rtl": "^13.0.0",
+        "@material/shape": "^13.0.0",
+        "@material/theme": "^13.0.0",
+        "@material/tokens": "^13.0.0",
+        "@material/touch-target": "^13.0.0",
+        "@material/typography": "^13.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab/node_modules/@material/animation": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0.tgz",
+      "integrity": "sha512-YR0/u4u56qXDjKYolQ7F+IvlPkaSBhMl/dZv8DK0FbD6PH4ckOPd3bEXNRndXtprsxwknQQP2pttjPImylkl0g==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@material/mwc-base": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.25.3.tgz",
-      "integrity": "sha512-4wvxZ9dhPr0O4jjOHPmFyn77pafe+h1gHPlT9sbQ+ly8NY/fSn/TXn7/PbxgL8g4ZHxMvD3o7PJopg+6cbHp8Q==",
+    "node_modules/@material/fab/node_modules/@material/base": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0.tgz",
+      "integrity": "sha512-vFx0JryRfcvUNX3cZ2u32wUMvxzd+c/YW0LFOXNgqCDWlubHcMm0Y6Wz371LhfQo80/NE69u+/4Joo99yKnVeg==",
       "dependencies": {
-        "@lit/reactive-element": "1.0.0-rc.4",
-        "@material/base": "=14.0.0-canary.261f2db59.0",
-        "@material/dom": "=14.0.0-canary.261f2db59.0",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-fab": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@material/mwc-fab/-/mwc-fab-0.25.3.tgz",
-      "integrity": "sha512-XE1BQNKAEear+Uq58s+DjZe6yw7kiiQofdayXjbKVRf5VS4Kdd0PDfb8sIYyRbwszknVB9jmisk9LQjHTfzs7w==",
-      "dependencies": {
-        "@material/mwc-ripple": "^0.25.3",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-ripple": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.25.3.tgz",
-      "integrity": "sha512-G/gt/csxgME6/sAku3GiuB0O2LLvoPWsRTLq/9iABpaGLJjqaKHvNg/IVzNDdF3YZT7EORgR9cBWWl7umA4i4Q==",
-      "dependencies": {
-        "@material/dom": "=14.0.0-canary.261f2db59.0",
-        "@material/mwc-base": "^0.25.3",
-        "@material/ripple": "=14.0.0-canary.261f2db59.0",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/ripple": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-3FLCLj8X7KrFfuYBHJg1b7Odb3V/AW7fxk3m1i1zhDnygKmlQ/abVucH1s2qbX3Y+JIiq+5/C5407h9BFtOf+A==",
-      "dependencies": {
-        "@material/animation": "14.0.0-canary.261f2db59.0",
-        "@material/base": "14.0.0-canary.261f2db59.0",
-        "@material/dom": "14.0.0-canary.261f2db59.0",
-        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
-        "@material/rtl": "14.0.0-canary.261f2db59.0",
-        "@material/theme": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@material/rtl": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-bVnXBbUsHs57+EXdeFbcwaKy3lT/itI/qTLmJ88ar0qaGEujO1GmESHm3ioqkeo4kQpTfDhBwQGeEi1aDaTdFg==",
+    "node_modules/@material/fab/node_modules/@material/dom": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-13.0.0.tgz",
+      "integrity": "sha512-M9HLAYBZtkTUvf66FL+jAEvUOdhji1HkGA1mV6oyE+HY9gkCkmso+mngvzlLd5+uaAVE9I3WQFhSb9gp0cpXnw==",
       "dependencies": {
-        "@material/theme": "14.0.0-canary.261f2db59.0",
+        "@material/feature-targeting": "^13.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab/node_modules/@material/feature-targeting": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0.tgz",
+      "integrity": "sha512-QJClfeaA4EMyAxKJy9WR0Nx+/VwSZCkhGLUVBG9NhxqYGfl/LtaeaidrNm32vYEoNZAofN92VD2RwQTRwp/dMQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab/node_modules/@material/ripple": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-13.0.0.tgz",
+      "integrity": "sha512-hx4B40hB2rRfsGwf1jwo2GGlYDq0yUQjcMcMmXfQipPJNpQhy8ylmXKc1DBjmWf7EQ/MgbfCSYwPrYXrbGP31w==",
+      "dependencies": {
+        "@material/animation": "^13.0.0",
+        "@material/base": "^13.0.0",
+        "@material/dom": "^13.0.0",
+        "@material/feature-targeting": "^13.0.0",
+        "@material/rtl": "^13.0.0",
+        "@material/theme": "^13.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab/node_modules/@material/rtl": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0.tgz",
+      "integrity": "sha512-nFGy3iQg7k+xLs67eb86mRFVLwa0yi7MusqRK4OM8DXcLO5yoVfUTPKpdSykcbRryp9imVHsxutox2tZawR4og==",
+      "dependencies": {
+        "@material/theme": "^13.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab/node_modules/@material/theme": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0.tgz",
+      "integrity": "sha512-KAe1s0MvvfCGAwJliDVTvgAKuD3ESwhl7F7br4Iam4IPdqME2rWl8NPhKHFfaWqTG7PyCgMMngYEYuA8cLNTsA==",
+      "dependencies": {
+        "@material/feature-targeting": "^13.0.0",
         "tslib": "^2.1.0"
       }
     },
@@ -1961,13 +1950,12 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@material/theme": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-bUqyFT0QF8Nxx02fekt3CXIfC9DEPOPdo2hjgdtvhrNP+vftbkI2tKZ5/uRUnVA+zqQAOyIl5z6FOMg4fyemCA==",
+    "node_modules/@material/tokens": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-13.0.0.tgz",
+      "integrity": "sha512-t55CKVeAjABdSQCKjsvYvqrA6Z4f5varLpLloai8ZQU0giSl7qbUczV1i8y2pSOzpRTswD5JKM7a19qfsl/TCA==",
       "dependencies": {
-        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
-        "tslib": "^2.1.0"
+        "@material/elevation": "^13.0.0"
       }
     },
     "node_modules/@material/top-app-bar": {
@@ -2043,6 +2031,51 @@
       }
     },
     "node_modules/@material/top-app-bar/node_modules/@material/theme": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0.tgz",
+      "integrity": "sha512-KAe1s0MvvfCGAwJliDVTvgAKuD3ESwhl7F7br4Iam4IPdqME2rWl8NPhKHFfaWqTG7PyCgMMngYEYuA8cLNTsA==",
+      "dependencies": {
+        "@material/feature-targeting": "^13.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-13.0.0.tgz",
+      "integrity": "sha512-2BMjj+nwKIYG7cZZGcNuRSKo53knqDu9ksv9wLidxjLgzqXBd1v9gdXsqMRQXepoOqftWGmYMaRYI0xMnxt6lA==",
+      "dependencies": {
+        "@material/base": "^13.0.0",
+        "@material/feature-targeting": "^13.0.0",
+        "@material/rtl": "^13.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target/node_modules/@material/base": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0.tgz",
+      "integrity": "sha512-vFx0JryRfcvUNX3cZ2u32wUMvxzd+c/YW0LFOXNgqCDWlubHcMm0Y6Wz371LhfQo80/NE69u+/4Joo99yKnVeg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target/node_modules/@material/feature-targeting": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0.tgz",
+      "integrity": "sha512-QJClfeaA4EMyAxKJy9WR0Nx+/VwSZCkhGLUVBG9NhxqYGfl/LtaeaidrNm32vYEoNZAofN92VD2RwQTRwp/dMQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target/node_modules/@material/rtl": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0.tgz",
+      "integrity": "sha512-nFGy3iQg7k+xLs67eb86mRFVLwa0yi7MusqRK4OM8DXcLO5yoVfUTPKpdSykcbRryp9imVHsxutox2tZawR4og==",
+      "dependencies": {
+        "@material/theme": "^13.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target/node_modules/@material/theme": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0.tgz",
       "integrity": "sha512-KAe1s0MvvfCGAwJliDVTvgAKuD3ESwhl7F7br4Iam4IPdqME2rWl8NPhKHFfaWqTG7PyCgMMngYEYuA8cLNTsA==",
@@ -11342,36 +11375,6 @@
       "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
       "dev": true
     },
-    "@lit/reactive-element": {
-      "version": "1.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.4.tgz",
-      "integrity": "sha512-dJMha+4NFYdpnUJzRrWTFV5Hdp9QHWFuPnaoqonrKl4lGJVnYez9mu8ev9F/5KM47tjAjh22DuRHrdFDHfOijA=="
-    },
-    "@material/animation": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-OjxWJYSRNs4vnPe8NclaNn+TsNc8TR/wHusGtezF5F+wl+5mh+K69BMXAmURtq3idoRg4XaOSC/Ohk1ovD1fMQ==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "@material/base": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-vy5SQt+jcwwdRFfBvtpVdpULUBujecVUKOXcopaQoi2XIzI5EBHuR4gPN0cd1yfmVEucD6p2fvVv2FJ3Ngr61w==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "@material/dom": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-iUpZG6Bb2l/PfNV2Fb/pXfG1p4Bz4PC9A7ATPlKfcU5HioObcnYVc/+Hrtaw8eu28BNIc+VVROtbfpqG/YgKSQ==",
-      "requires": {
-        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
-        "tslib": "^2.1.0"
-      }
-    },
     "@material/elevation": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-13.0.0.tgz",
@@ -11429,69 +11432,90 @@
         }
       }
     },
-    "@material/feature-targeting": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
+    "@material/fab": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-13.0.0.tgz",
+      "integrity": "sha512-qOi+XWEZWUR5T961UjSorgqm5VaanuZtRN3nsrKqHH1p0L8fYRc3qkGIChlaY9p7BcOYMCynXJzT+MfELVrcwA==",
       "requires": {
+        "@material/animation": "^13.0.0",
+        "@material/dom": "^13.0.0",
+        "@material/elevation": "^13.0.0",
+        "@material/feature-targeting": "^13.0.0",
+        "@material/ripple": "^13.0.0",
+        "@material/rtl": "^13.0.0",
+        "@material/shape": "^13.0.0",
+        "@material/theme": "^13.0.0",
+        "@material/tokens": "^13.0.0",
+        "@material/touch-target": "^13.0.0",
+        "@material/typography": "^13.0.0",
         "tslib": "^2.1.0"
-      }
-    },
-    "@material/mwc-base": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.25.3.tgz",
-      "integrity": "sha512-4wvxZ9dhPr0O4jjOHPmFyn77pafe+h1gHPlT9sbQ+ly8NY/fSn/TXn7/PbxgL8g4ZHxMvD3o7PJopg+6cbHp8Q==",
-      "requires": {
-        "@lit/reactive-element": "1.0.0-rc.4",
-        "@material/base": "=14.0.0-canary.261f2db59.0",
-        "@material/dom": "=14.0.0-canary.261f2db59.0",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      }
-    },
-    "@material/mwc-fab": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@material/mwc-fab/-/mwc-fab-0.25.3.tgz",
-      "integrity": "sha512-XE1BQNKAEear+Uq58s+DjZe6yw7kiiQofdayXjbKVRf5VS4Kdd0PDfb8sIYyRbwszknVB9jmisk9LQjHTfzs7w==",
-      "requires": {
-        "@material/mwc-ripple": "^0.25.3",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      }
-    },
-    "@material/mwc-ripple": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.25.3.tgz",
-      "integrity": "sha512-G/gt/csxgME6/sAku3GiuB0O2LLvoPWsRTLq/9iABpaGLJjqaKHvNg/IVzNDdF3YZT7EORgR9cBWWl7umA4i4Q==",
-      "requires": {
-        "@material/dom": "=14.0.0-canary.261f2db59.0",
-        "@material/mwc-base": "^0.25.3",
-        "@material/ripple": "=14.0.0-canary.261f2db59.0",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      }
-    },
-    "@material/ripple": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-3FLCLj8X7KrFfuYBHJg1b7Odb3V/AW7fxk3m1i1zhDnygKmlQ/abVucH1s2qbX3Y+JIiq+5/C5407h9BFtOf+A==",
-      "requires": {
-        "@material/animation": "14.0.0-canary.261f2db59.0",
-        "@material/base": "14.0.0-canary.261f2db59.0",
-        "@material/dom": "14.0.0-canary.261f2db59.0",
-        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
-        "@material/rtl": "14.0.0-canary.261f2db59.0",
-        "@material/theme": "14.0.0-canary.261f2db59.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@material/rtl": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-bVnXBbUsHs57+EXdeFbcwaKy3lT/itI/qTLmJ88ar0qaGEujO1GmESHm3ioqkeo4kQpTfDhBwQGeEi1aDaTdFg==",
-      "requires": {
-        "@material/theme": "14.0.0-canary.261f2db59.0",
-        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0.tgz",
+          "integrity": "sha512-YR0/u4u56qXDjKYolQ7F+IvlPkaSBhMl/dZv8DK0FbD6PH4ckOPd3bEXNRndXtprsxwknQQP2pttjPImylkl0g==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/base": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0.tgz",
+          "integrity": "sha512-vFx0JryRfcvUNX3cZ2u32wUMvxzd+c/YW0LFOXNgqCDWlubHcMm0Y6Wz371LhfQo80/NE69u+/4Joo99yKnVeg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/dom": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-13.0.0.tgz",
+          "integrity": "sha512-M9HLAYBZtkTUvf66FL+jAEvUOdhji1HkGA1mV6oyE+HY9gkCkmso+mngvzlLd5+uaAVE9I3WQFhSb9gp0cpXnw==",
+          "requires": {
+            "@material/feature-targeting": "^13.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0.tgz",
+          "integrity": "sha512-QJClfeaA4EMyAxKJy9WR0Nx+/VwSZCkhGLUVBG9NhxqYGfl/LtaeaidrNm32vYEoNZAofN92VD2RwQTRwp/dMQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/ripple": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-13.0.0.tgz",
+          "integrity": "sha512-hx4B40hB2rRfsGwf1jwo2GGlYDq0yUQjcMcMmXfQipPJNpQhy8ylmXKc1DBjmWf7EQ/MgbfCSYwPrYXrbGP31w==",
+          "requires": {
+            "@material/animation": "^13.0.0",
+            "@material/base": "^13.0.0",
+            "@material/dom": "^13.0.0",
+            "@material/feature-targeting": "^13.0.0",
+            "@material/rtl": "^13.0.0",
+            "@material/theme": "^13.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/rtl": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0.tgz",
+          "integrity": "sha512-nFGy3iQg7k+xLs67eb86mRFVLwa0yi7MusqRK4OM8DXcLO5yoVfUTPKpdSykcbRryp9imVHsxutox2tZawR4og==",
+          "requires": {
+            "@material/theme": "^13.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0.tgz",
+          "integrity": "sha512-KAe1s0MvvfCGAwJliDVTvgAKuD3ESwhl7F7br4Iam4IPdqME2rWl8NPhKHFfaWqTG7PyCgMMngYEYuA8cLNTsA==",
+          "requires": {
+            "@material/feature-targeting": "^13.0.0",
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@material/shape": {
@@ -11533,13 +11557,12 @@
         }
       }
     },
-    "@material/theme": {
-      "version": "14.0.0-canary.261f2db59.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.261f2db59.0.tgz",
-      "integrity": "sha512-bUqyFT0QF8Nxx02fekt3CXIfC9DEPOPdo2hjgdtvhrNP+vftbkI2tKZ5/uRUnVA+zqQAOyIl5z6FOMg4fyemCA==",
+    "@material/tokens": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-13.0.0.tgz",
+      "integrity": "sha512-t55CKVeAjABdSQCKjsvYvqrA6Z4f5varLpLloai8ZQU0giSl7qbUczV1i8y2pSOzpRTswD5JKM7a19qfsl/TCA==",
       "requires": {
-        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
-        "tslib": "^2.1.0"
+        "@material/elevation": "^13.0.0"
       }
     },
     "@material/top-app-bar": {
@@ -11602,6 +11625,53 @@
             "@material/feature-targeting": "^13.0.0",
             "@material/rtl": "^13.0.0",
             "@material/theme": "^13.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/rtl": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-13.0.0.tgz",
+          "integrity": "sha512-nFGy3iQg7k+xLs67eb86mRFVLwa0yi7MusqRK4OM8DXcLO5yoVfUTPKpdSykcbRryp9imVHsxutox2tZawR4og==",
+          "requires": {
+            "@material/theme": "^13.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-13.0.0.tgz",
+          "integrity": "sha512-KAe1s0MvvfCGAwJliDVTvgAKuD3ESwhl7F7br4Iam4IPdqME2rWl8NPhKHFfaWqTG7PyCgMMngYEYuA8cLNTsA==",
+          "requires": {
+            "@material/feature-targeting": "^13.0.0",
+            "tslib": "^2.1.0"
+          }
+        }
+      }
+    },
+    "@material/touch-target": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-13.0.0.tgz",
+      "integrity": "sha512-2BMjj+nwKIYG7cZZGcNuRSKo53knqDu9ksv9wLidxjLgzqXBd1v9gdXsqMRQXepoOqftWGmYMaRYI0xMnxt6lA==",
+      "requires": {
+        "@material/base": "^13.0.0",
+        "@material/feature-targeting": "^13.0.0",
+        "@material/rtl": "^13.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@material/base": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-13.0.0.tgz",
+          "integrity": "sha512-vFx0JryRfcvUNX3cZ2u32wUMvxzd+c/YW0LFOXNgqCDWlubHcMm0Y6Wz371LhfQo80/NE69u+/4Joo99yKnVeg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-13.0.0.tgz",
+          "integrity": "sha512-QJClfeaA4EMyAxKJy9WR0Nx+/VwSZCkhGLUVBG9NhxqYGfl/LtaeaidrNm32vYEoNZAofN92VD2RwQTRwp/dMQ==",
+          "requires": {
             "tslib": "^2.1.0"
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "llaminator",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -30,6 +29,7 @@
         "sass-loader": "^12.4.0",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",
+        "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.6.0",
         "workbox-webpack-plugin": "^6.4.2"
@@ -2113,6 +2113,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+      "dev": true
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -2556,7 +2562,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
       "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2572,6 +2577,15 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -4778,6 +4792,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5462,6 +5482,21 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
+    },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -6789,6 +6824,15 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mrmime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.0.tgz",
+      "integrity": "sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -7029,6 +7073,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/os-homedir": {
@@ -8528,6 +8581,20 @@
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
     },
+    "node_modules/sirv": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
+      "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8991,6 +9058,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tr46": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -9302,6 +9378,59 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz",
+      "integrity": "sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^7.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }
@@ -11551,6 +11680,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+      "dev": true
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -11943,8 +12078,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
       "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
@@ -11953,6 +12087,12 @@
       "dev": true,
       "peer": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -13288,9 +13428,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -13460,9 +13598,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -13778,6 +13914,12 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -14307,6 +14449,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
+    },
+    "gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.2"
+      }
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -15311,6 +15462,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "mrmime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.0.tgz",
+      "integrity": "sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -15486,6 +15643,12 @@
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
       }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -16540,6 +16703,17 @@
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
     },
+    "sirv": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
+      "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^1.0.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16879,6 +17053,12 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "dev": true
+    },
     "tr46": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -17115,6 +17295,38 @@
         "webpack-sources": "^3.2.2"
       }
     },
+    "webpack-bundle-analyzer": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz",
+      "integrity": "sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^7.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        },
+        "ws": {
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
     "webpack-cli": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
@@ -17173,9 +17385,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -17256,9 +17466,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "sass-loader": "^12.4.0",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.2",
+    "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.6.0",
     "workbox-webpack-plugin": "^6.4.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "workbox-webpack-plugin": "^6.4.2"
   },
   "dependencies": {
-    "@material/mwc-fab": "^0.25.3",
+    "@material/fab": "^13.0.0",
     "@material/top-app-bar": "^13.0.0",
     "idb": "^7.0.0",
     "lit": "^2.0.2",

--- a/src/components/llama-select-fab.ts
+++ b/src/components/llama-select-fab.ts
@@ -37,7 +37,7 @@ export class LlamaSelectFab extends LitElement {
 
   render() {
     return html`
-      <div class="mdc-touch-target-wrapper llama-upload-button">
+      <div class="mdc-touch-target-wrapper">
         <button class="mdc-fab mdc-fab--touch">
           <label aria-label="Select a file to store in Llaminator" for="select">
             <input type="file" accept="image/*" id="select" hidden

--- a/src/components/llama-select-fab.ts
+++ b/src/components/llama-select-fab.ts
@@ -14,26 +14,14 @@
  *  limitations under the License.
  */
 
-import '@material/mwc-fab';
-
-import { LitElement, css, html } from 'lit';
+import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElement('llama-select-fab')
 export class LlamaSelectFab extends LitElement {
-  static get styles() {
-    return css`
-      #root {
-        position: absolute;
-        display: block;
-        bottom: 32px;
-        right: 32px;
-      }
-
-      mwc-fab {
-        pointer-events: none;
-      }`;
-  }
+  // No internal behaviour is necessary for the header, so avoid creating an
+  // open shadow root for this component and default to global styles instead.
+  createRenderRoot() { return this; }
 
   handleInputChange(event: Event) {
     if (!(event.target instanceof HTMLInputElement))
@@ -49,13 +37,16 @@ export class LlamaSelectFab extends LitElement {
 
   render() {
     return html`
-      <input type="file" accept="image/*"
-             id="select" hidden
-             @change=${this.handleInputChange} />
-      <label id="root" for="select">
-        <mwc-fab icon="file_upload"
-                 label="Select a file to store in Llaminator">
-        </mwc-fab>
-      </label>`;
+      <div class="mdc-touch-target-wrapper llama-upload-button">
+        <button class="mdc-fab mdc-fab--touch">
+          <label aria-label="Select a file to store in Llaminator" for="select">
+            <input type="file" accept="image/*" id="select" hidden
+                   @change=${this.handleInputChange} />
+            <div class="mdc-fab__ripple"></div>
+            <span class="material-icons mdc-fab__icon">file_upload</span>
+            <div class="mdc-fab__touch"></div>
+          </label>
+        </button>
+      </div>`;
   }
 }

--- a/src/llaminator.scss
+++ b/src/llaminator.scss
@@ -14,6 +14,7 @@
  *  limitations under the License.
  */
 
+@use '@material/fab/mdc-fab';
 @use '@material/top-app-bar/mdc-top-app-bar';
 
 * {
@@ -30,4 +31,11 @@ html {
 html, body {
   width: 100%;
   height: 100%;
+}
+
+llama-select-fab {
+  position: absolute;
+  display: block;
+  bottom: 32px;
+  right: 32px;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@
 
 const path = require('path');
 
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -36,6 +37,11 @@ module.exports = (env, options) => {
       inject: 'body',
     }),
     new CssMinimizerPlugin(),
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      openAnalyzer: false,
+      reportFilename: 'index-sizes.html',
+    }),
   ];
 
   // When hot code reloading is used in development environments, Workbox is


### PR DESCRIPTION
This re-implements the file selection fab without relying on MWC. Our uncompressed JavaScript bundle size decreases by a massive 49KiB, whereas our CSS file grows by 7KiB. Appearance remains identical, although we now have the ability to add ripple styles to the fab ourselves. (Hover styles are already enabled.)

Live on https://llaminator.peter.sh/