### PR TITLE
Customize eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,5 +15,25 @@
         "@typescript-eslint"
     ],
     "rules": {
+        "block-spacing": ["error", "always"],
+        "brace-style": ["error", "1tbs", {
+            "allowSingleLine": true
+        }],
+        "max-len": ["error", {
+            "code": 100,
+            "tabWidth": 2,
+            "ignoreUrls": true,
+            "ignorePattern": "goog.(module|require)"
+        }],
+        "object-curly-spacing": ["error", "always"],
+        "require-jsdoc": ["warn", {
+            "require": {
+              "FunctionDeclaration": true,
+              "MethodDefinition": true,
+              "ClassDeclaration": true,
+              "ArrowFunctionExpression": false,
+              "FunctionExpression": false
+            }
+        }]
     }
 }


### PR DESCRIPTION
This implements most of the tweaks discussed in
https://github.com/GoogleChromeLabs/llaminator/issues/65.

Since it doesn't seem like we can require jsdoc based on
public/private status, I switched the jsdoc rule to a
warning instead of an error.

Most of the configs specified under "max-len" and
"require-jsdoc" are the same as before - I copied them
from running `eslint --print-config .eslintrc.json` on
the default config.

Here's what happens when I run `eslint --fix` with the
config in this commit:
https://github.com/glennhartmann/llaminator/commit/a7397cfcf31bdee93de7c45189e1f5f22acaff12