### PR TITLE
Set up eslint-plugin-jsonc and eslint-plugin-json-schema-validator

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .tmp/
 dist/
 node_modules/
+package-lock.json

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,14 @@
         "es2021": true
     },
     "extends": [
-        "google"
+        "google",
+        "plugin:jsonc/recommended-with-json"
+    ],
+    "overrides": [
+      {
+        "files": ["*.json", "*.json5", "*.jsonc"],
+        "parser": "jsonc-eslint-parser"
+      }
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -12,7 +19,9 @@
         "sourceType": "module"
     },
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "json-schema-validator",
+        "jsonc"
     ],
     "rules": {
         "block-spacing": ["error", "always"],
@@ -34,6 +43,16 @@
               "ArrowFunctionExpression": false,
               "FunctionExpression": false
             }
-        }]
+        }],
+        "json-schema-validator/no-invalid": ["error", {
+            "schemas": [
+                {
+                    "fileMatch": ["manifest.json"],
+                    "schema": "https://json.schemastore.org/web-manifest-combined.json"
+                }
+            ],
+            "useSchemastoreCatalog": false
+        }],
+        "jsonc/auto": "error"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
         "css-minimizer-webpack-plugin": "^3.2.0",
         "eslint": "^8.6.0",
         "eslint-config-google": "^0.14.0",
+        "eslint-plugin-json-schema-validator": "^2.1.29",
+        "eslint-plugin-jsonc": "^2.0.0",
         "extract-loader": "^5.1.0",
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.5.0",
@@ -6792,6 +6794,94 @@
         "eslint": ">=5.16.0"
       }
     },
+    "node_modules/eslint-plugin-json-schema-validator": {
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-2.1.29.tgz",
+      "integrity": "sha512-w7x2lIWSefKK7+Yd+rDTEfBHDLnfvbeago/tcqdDY8swFs19Wo7ZYAqgGVmR3YUQC4ft4YIZdlCCG/KSvZGqJA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "debug": "^4.3.1",
+        "eslint-utils": "^3.0.0",
+        "json-schema-migrate": "^2.0.0",
+        "jsonc-eslint-parser": "^2.0.0",
+        "minimatch": "^3.0.4",
+        "toml-eslint-parser": "^0.3.0",
+        "tunnel-agent": "^0.6.0",
+        "yaml-eslint-parser": "^0.5.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/ajv": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-jsonc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.0.0.tgz",
+      "integrity": "sha512-5UbUUvx4gUVeF9hJ+SHDW9a4OPQ8vJWu12rttQ76qGO2tlH17OC103CLq+vrmjo5VQULeVzSJ0u4s+jUATJyWQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "jsonc-eslint-parser": "^2.0.1",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -9900,6 +9990,37 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
+    "node_modules/json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/ajv": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9925,6 +10046,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.0.4.tgz",
+      "integrity": "sha512-a3ZRus4qea0tSRCW2qvF/spFt7iCpdeJbiDjxbFZRZ87JCF8sI8hbxpVvUBVyZ3fLB/RQnTi+Y/yZbMlqt1BCg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/jsonfile": {
@@ -13261,6 +13398,18 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toml-eslint-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.3.0.tgz",
+      "integrity": "sha512-oHSO8avJ1nANY6DOgpyMTSN+HpGv7nlg5rO5pcnnud0cUxq8s3IhUe8dGXsnX4ut+0azcaxGXQ/pWe0OR6Kjxg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/totalist": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
@@ -13364,6 +13513,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -14535,6 +14696,20 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yaml-eslint-parser": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-0.5.0.tgz",
+      "integrity": "sha512-nJeyLA3YHAzhBTZbRAbu3W6xrSCucyxExmA+ZDtEdUFpGllxAZpto2Zxo2IG0r0eiuEiBM4e+wiAdxTziTq94g==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.0.0",
+        "lodash": "^4.17.21",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/yargs": {
@@ -20012,6 +20187,69 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-plugin-json-schema-validator": {
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-2.1.29.tgz",
+      "integrity": "sha512-w7x2lIWSefKK7+Yd+rDTEfBHDLnfvbeago/tcqdDY8swFs19Wo7ZYAqgGVmR3YUQC4ft4YIZdlCCG/KSvZGqJA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0",
+        "debug": "^4.3.1",
+        "eslint-utils": "^3.0.0",
+        "json-schema-migrate": "^2.0.0",
+        "jsonc-eslint-parser": "^2.0.0",
+        "minimatch": "^3.0.4",
+        "toml-eslint-parser": "^0.3.0",
+        "tunnel-agent": "^0.6.0",
+        "yaml-eslint-parser": "^0.5.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsonc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.0.0.tgz",
+      "integrity": "sha512-5UbUUvx4gUVeF9hJ+SHDW9a4OPQ8vJWu12rttQ76qGO2tlH17OC103CLq+vrmjo5VQULeVzSJ0u4s+jUATJyWQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "jsonc-eslint-parser": "^2.0.1",
+        "natural-compare": "^1.4.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -22263,6 +22501,35 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
+    "json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -22282,6 +22549,19 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonc-eslint-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.0.4.tgz",
+      "integrity": "sha512-a3ZRus4qea0tSRCW2qvF/spFt7iCpdeJbiDjxbFZRZ87JCF8sI8hbxpVvUBVyZ3fLB/RQnTi+Y/yZbMlqt1BCg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.5.0",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
       }
     },
     "jsonfile": {
@@ -24764,6 +25044,15 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "toml-eslint-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.3.0.tgz",
+      "integrity": "sha512-oHSO8avJ1nANY6DOgpyMTSN+HpGv7nlg5rO5pcnnud0cUxq8s3IhUe8dGXsnX4ut+0azcaxGXQ/pWe0OR6Kjxg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.0.0"
+      }
+    },
     "totalist": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
@@ -24842,6 +25131,15 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "type-check": {
@@ -25764,6 +26062,17 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
+    },
+    "yaml-eslint-parser": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-0.5.0.tgz",
+      "integrity": "sha512-nJeyLA3YHAzhBTZbRAbu3W6xrSCucyxExmA+ZDtEdUFpGllxAZpto2Zxo2IG0r0eiuEiBM4e+wiAdxTziTq94g==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.0.0",
+        "lodash": "^4.17.21",
+        "yaml": "^1.10.2"
+      }
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Llaminator helps you store and access images directly from your browser.",
   "scripts": {
     "build": "webpack --mode=production",
-    "lint": "eslint './**/*.js' './**/*.ts'",
+    "lint": "eslint './**/*.js' './**/*.ts' './**/*.json'",
     "serve": "webpack serve --open --mode=development",
     "test": "jest"
   },
@@ -26,6 +26,8 @@
     "css-minimizer-webpack-plugin": "^3.2.0",
     "eslint": "^8.6.0",
     "eslint-config-google": "^0.14.0",
+    "eslint-plugin-json-schema-validator": "^2.1.29",
+    "eslint-plugin-jsonc": "^2.0.0",
     "extract-loader": "^5.1.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",


### PR DESCRIPTION
This lets our eslint setup also lint JSON files
(with settings very similar to our existing
js/ts rules), and also partially validates the
manifest.json schema ("partially" meaning that
I think it does not currently validate the Web Share
Target part).

`eslint --fix './**/*.json'` looks like
https://github.com/glennhartmann/llaminator/commit/3d198b30275d8e8e50904dfd4f405a2a145c2ccc

(Note: this depends on https://github.com/GoogleChromeLabs/llaminator/pull/68)

More linters (HTML, CSS? yaml?) coming later, all part of https://github.com/GoogleChromeLabs/llaminator/issues/15
(discussions can continue to happen on https://github.com/GoogleChromeLabs/llaminator/issues/65)