### PR TITLE
Don't crop images

### DIFF
--- a/src/components/llama-item.ts
+++ b/src/components/llama-item.ts
@@ -60,7 +60,7 @@ export class LlamaItem extends LitElement {
     return html`
       <div class="mdc-card">
         <div class="mdc-card__primary-action">
-          <div class="mdc-card__media mdc-card__media--16-9" style="background-image: url(${this.src})">
+          <div class="mdc-card__media mdc-card__media--16-9 llama-card-media" style="background-image: url(${this.src})">
           </div>
           <!-- TODO: Display filename/date/time information? -->
           <!-- TODO: Add a ripple effect -->

--- a/src/llaminator.scss
+++ b/src/llaminator.scss
@@ -57,6 +57,6 @@ llama-select-fab {
   right: 32px;
 }
 
-.mdc-card__media {
+.llama-card-media {
   background-size: contain;
 }

--- a/src/llaminator.scss
+++ b/src/llaminator.scss
@@ -56,3 +56,7 @@ llama-select-fab {
   bottom: 32px;
   right: 32px;
 }
+
+.mdc-card__media {
+  background-size: contain;
+}


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/llaminator/issues/70

After patch: 
<img width="1151" alt="Screenshot 2022-01-09 161728" src="https://user-images.githubusercontent.com/570079/148701407-6580e350-59eb-4831-af9b-9b5222a75191.png">
