### PR TITLE
Add a test for <llama-select-fab>'s "fileselected" event

### DIFF
--- a/src/components/llama-select-fab.test.js
+++ b/src/components/llama-select-fab.test.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const path = require('path');
+
+// Building the website and starting the server takes ~7 seconds on a MacBook Pro.
+jest.setTimeout(15000);
+
+describe('LlamaSelectFab', () => {
+  it('fires an event when a file has been selected', async () => {
+    await page.goto('http://localhost:8888', { 'waitUntil': 'domcontentloaded' });
+
+    const selectHandle = await page.$('llama-select-fab');
+    const inputHandle = await selectHandle?.$('input[type="file"]');
+    expect(inputHandle).not.toBeNull();
+
+    let selectedFilename;
+
+    await page.exposeFunction('setSelectedFilenameForTesting', file => {
+      selectedFilename = file;
+    });
+
+    await selectHandle?.evaluate(selectElement => {
+      selectElement.addEventListener('fileselected', event => {
+        window.setSelectedFilenameForTesting(event.detail.name);
+      });
+    })
+
+    // While browsers will honour the @accept attribute of uploaded files, Llaminator contains no
+    // logic to do filtering of its own. This shortcut avoids relying on an external dependency.
+    const currentFile = __filename;
+
+    await inputHandle?.uploadFile(currentFile);
+    await inputHandle?.evaluate(inputElement =>
+        inputElement.dispatchEvent(new Event('change', { bubbles: true })));
+
+    expect(selectedFilename).not.toBeUndefined();
+    expect(selectedFilename).toEqual(path.basename(currentFile));
+  });
+});


### PR DESCRIPTION
This stuff is fascinating.

First, TypeScript isn't supported yet. It's not just the types - adding those is easy, it's that Babel has to be set up to translate the test files prior to executing them. That should be done in a separate PR.

Second, while it makes sense for Puppeteer to work this way, having two JavaScript contexts in the same file is _confusing_. The event listener I add in `evaluate()` is executed in the page's context. Transferring data to the test context requires exposing a function (`setSelectedFilenameForTesting`). This seems to only support limited cloning, so I can't transfer the full event, nor the `File` instance, thus have to settle on just using the filename.

The rest is straightforward enough. I decided to upload the current file to avoid needing to check in a resource for testing purposes—the filtering logic is not ours anyway. We should figure out how to share code for some of the environment set-up across tests.

@PEConn I notice that you created a `tests/` directory. In this PR I'm adding a test to live next to the file it's testing something for, which I think is cleaner. Thoughts?