### PR TITLE
Refactor llaminator.ts to allow alternative layouts.

### DIFF
--- a/src/components/layouts/llama-vertical-scroll-layout.ts
+++ b/src/components/layouts/llama-vertical-scroll-layout.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { LitElement, html, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import { LlamaStorage } from '../../storage';
+
+@customElement('llama-vertical-scroll-layout')
+/**
+ * Default Llaminator layout - renders all items at once, vertically in a single column, and lets
+ * the browser handle scrolling in the normal way. Implements ../../llaminator.Layout.
+ */
+export class LlamaVerticalScrollLayout extends LitElement {
+  /**
+   * This component needs an open shadow root because LlamaItem depends on it.
+   *
+   * @return {LlamaVerticalScrollLayout} The current instance.
+   */
+  createRenderRoot() { return this; }
+  items: TemplateResult[] = [];
+
+  /**
+   * Refreshes (ie, renders) the layout's contents from the database.
+   *
+   * @param {LlamaStorage} database The database of items to render.
+   */
+  async refresh(database: LlamaStorage) {
+    const items = [];
+
+    for (const item of await database.list()) {
+      const blob = await database.getFile(item.id);
+      if (!blob) {
+        // TODO: Display an error, or prune this item from the database.
+        continue;
+      }
+
+      const url = URL.createObjectURL(blob);
+
+      items.push(html`
+          <llama-item .storage=${database} id=${item.id} src=${url}>
+          </llama-item>`);
+    }
+
+    this.items = items;
+    this.requestUpdate();
+  }
+
+  /**
+   * Called by lit when it's time to render the lit-element component. Calling this function does
+   * _not_ actually trigger anything to be rendered.
+   *
+   * @return {TemplateResult} The html template for lit to render.
+   */
+  render() {
+    return this.items;
+  }
+}

--- a/src/components/layouts/llama-vertical-scroll-layout.ts
+++ b/src/components/layouts/llama-vertical-scroll-layout.ts
@@ -14,24 +14,29 @@
  *  limitations under the License.
  */
 
-import { LitElement, html, TemplateResult } from 'lit';
+import { LitElement, TemplateResult, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
+import { LlamaLayout } from '../../llama-layout';
 import { LlamaStorage } from '../../storage';
 
 @customElement('llama-vertical-scroll-layout')
 /**
  * Default Llaminator layout - renders all items at once, vertically in a single column, and lets
- * the browser handle scrolling in the normal way. Implements ../../llaminator.Layout.
+ * the browser handle scrolling in the normal way.
  */
-export class LlamaVerticalScrollLayout extends LitElement {
+export class LlamaVerticalScrollLayout extends LitElement implements LlamaLayout {
+  /**
+   * html templates of LlamaItems.
+   */
+  items: TemplateResult[] = [];
+
   /**
    * This component needs an open shadow root because LlamaItem depends on it.
    *
    * @return {LlamaVerticalScrollLayout} The current instance.
    */
   createRenderRoot() { return this; }
-  items: TemplateResult[] = [];
 
   /**
    * Refreshes (ie, renders) the layout's contents from the database.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
 import { type LlamaSelectFab } from './components/llama-select-fab';
 import { Llaminator } from './llaminator';
 
+import './components/layouts/llama-vertical-scroll-layout';
 import './components/llama-header';
 import './components/llama-item';
 import './components/llama-select-fab';
@@ -33,11 +34,14 @@ if ('serviceWorker' in navigator && process.env.NODE_ENV !== 'development') {
 window.addEventListener('load', () => {
   if (!window.indexedDB || !window.URL) { /* TODO: display error message */ }
 
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const layoutParam = urlSearchParams.get('layout');
+  const layout = layoutParam ? layoutParam : 'vertical-scroll';
+
   const llaminator = new Llaminator({
     container: document.querySelector('main') as HTMLElement,
     select: document.querySelector('#input') as LlamaSelectFab,
-  });
+  }, layout);
 
-  llaminator.clearContainer();
-  llaminator.populate();
+  llaminator.resetContainer();
 });

--- a/src/llama-layout.ts
+++ b/src/llama-layout.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { LlamaStorage } from './storage';
+
+/**
+ * For components that define the overall layout of items on the page.
+ */
+export interface LlamaLayout {
+  /**
+   * Refreshes (ie, renders) the layout's contents from the database.
+   *
+   * @param {LlamaStorage} database The database of items to render.
+   */
+  refresh(database: LlamaStorage): void;
+}

--- a/src/llaminator.ts
+++ b/src/llaminator.ts
@@ -16,6 +16,7 @@
 
 import { render } from 'lit-html';
 
+import { type LlamaLayout } from './llama-layout';
 import { type LlamaSelectFab } from './components/llama-select-fab';
 import { LlamaStorage } from './storage';
 import { LlamaVerticalScrollLayout } from './components/layouts/llama-vertical-scroll-layout';
@@ -36,10 +37,6 @@ interface LlaminatorElements {
   select: LlamaSelectFab;
 }
 
-interface Layout {
-  refresh(database: LlamaStorage): void;
-}
-
 /**
  * Main class of the Llaminator application, which encapsulates the main functionality of the app.
  * Is given a series of HTML elements (`LlaminatorElements`) in which the app is to be rendered.
@@ -47,7 +44,7 @@ interface Layout {
 export class Llaminator {
   private readonly elements: LlaminatorElements;
   private readonly storage: Promise<LlamaStorage>;
-  private readonly layout: Layout;
+  private readonly layout: LlamaLayout;
 
   /**
    * Constructs a Llaminator instance.
@@ -83,8 +80,8 @@ export class Llaminator {
       container.firstChild.remove();
     }
 
-    render(this.layout, this.elements.container);
     this.layout.refresh(await this.storage);
+    render(this.layout, this.elements.container);
   }
 
   /**


### PR DESCRIPTION
Specifying the layout with a query param will let
us play around with some alternative prototypes.
In the future maybe we can have a user preference
to let the user decide how to display contents, or
we could have different layouts depending on the
screen size and orientation.

A couple of unintuitive things I ran into with Lit:
* updating an array that is bound to the custom element's
  html template doesn't seem to trigger an update (unless
  I was doing it wrong somehow)
* calling an element's `render()` function doesn't actually
  render anything. Especially confusing given that Lit's
  [other render function](https://github.com/GoogleChromeLabs/llaminator/commit/98a31481959cf1b15702aae3d62bae99f9c51548#diff-fdd4d1941d86cf4fd26f29614c10f2b6b6baccb1d46b6eaa4e357768ef555fadR86)
  does actually trigger rendering.

Admittedly these are both probably "RTFM" issues, but still
seem quite unintuitive to me.