### PR TITLE
Use "private" per-user firebase storage directories.

### DIFF
--- a/firebase_config/storage.rules
+++ b/firebase_config/storage.rules
@@ -1,8 +1,10 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /public/{allPaths=**} {
-      allow read, write: if true;
+    match /users/{userId}/{allPaths=**} {
+      // TODO: consider adding storage size limits here. Example:
+      // https://firebase.google.com/docs/storage/security/rules-conditions#validate_data
+      allow read, write: if request.auth.uid == userId;
     }
     match /{allPaths=**} {
       allow read, write: if false;

--- a/src/components/llama-sign-in-out-button.ts
+++ b/src/components/llama-sign-in-out-button.ts
@@ -58,7 +58,6 @@ export class LlamaSignInOutButton extends LitElement {
     this.auth = getAuth(app);
 
     this.auth.onAuthStateChanged((user) => {
-      console.info(user);
       this.stateStr = user ? 'Out' : 'In';
       this.user = user?.email || '';
     });

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -22,7 +22,7 @@ import { getStorage, FirebaseStorage } from 'firebase/storage';
 // TODO: the config should probably be in a separate JSON file.
 export const firebaseConfig = null;
 
-let app: FirebaseApp | null = null;
+export let firebaseApp: FirebaseApp | null = null;
 export let firebaseStorage: FirebaseStorage | null = null;
 
 /**
@@ -31,7 +31,7 @@ export let firebaseStorage: FirebaseStorage | null = null;
  * @return {boolean} Whether initialization was successful.
  */
 export function firebaseInit(): boolean {
-  app = firebaseConfig ? initializeApp(firebaseConfig) : null;
-  firebaseStorage = app ? getStorage(app) : null;
+  firebaseApp = firebaseConfig ? initializeApp(firebaseConfig) : null;
+  firebaseStorage = firebaseApp ? getStorage(firebaseApp) : null;
   return !!firebaseStorage;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,8 @@ import './components/llama-item';
 import './components/llama-select-fab';
 import './components/llama-sign-in-out-button';
 import './llaminator.scss';
-import { firebaseInit } from './firebase';
+import { firebaseApp, firebaseInit } from './firebase';
+import { getAuth } from 'firebase/auth';
 
 if ('serviceWorker' in navigator && process.env.NODE_ENV !== 'development') {
   window.addEventListener('load', () => {
@@ -52,5 +53,13 @@ window.addEventListener('load', () => {
     select: document.querySelector('#input') as LlamaSelectFab,
   }, layout);
 
-  llaminator.resetContainer();
+  llaminator.resetContainer(true /* clear */);
+
+  if (firebaseSyncParam === 'true' && firebaseApp) {
+    // Once the user logs in (or firebase realizes that the user is already logged in), we need to
+    // refresh the layout to load images from their remote storage bucket directory.
+    getAuth(firebaseApp).onAuthStateChanged(() => {
+      llaminator.resetContainer(false /* clear */);
+    });
+  }
 });

--- a/src/llaminator.ts
+++ b/src/llaminator.ts
@@ -77,13 +77,19 @@ export class Llaminator {
   }
 
   /**
-   * Clears the existing content from the container, then renders |this.layout| in it.
+   * Optionally clears the existing content from the container, then renders |this.layout| in it.
+   *
+   * @param {boolean} clear Whether to clear the existing content before rendering the layout. Note
+   *     that this generally should only be set the first time the function is called, because
+   *     removing the layout could mess up Lit's lifecycle stuff.
    */
-  async resetContainer() {
-    const { container } = this.elements;
+  async resetContainer(clear: boolean) {
+    if (clear) {
+      const { container } = this.elements;
 
-    while (container.firstChild) {
-      container.firstChild.remove();
+      while (container.firstChild) {
+        container.firstChild.remove();
+      }
     }
 
     this.layout.refresh(await this.storage);


### PR DESCRIPTION
"private" is in quotes because the owner of the storage bucket can see the data that users upload (hence the eventual need for https://github.com/GoogleChromeLabs/llaminator/issues/106).

This fixes https://github.com/GoogleChromeLabs/llaminator/issues/105.